### PR TITLE
Implement NextAuth Google OAuth

### DIFF
--- a/ai_front/nextjs-dashboard/package.json
+++ b/ai_front/nextjs-dashboard/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",
     "react-syntax-highlighter": "^15.6.1",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "next-auth": "^4.24.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/ai_front/nextjs-dashboard/src/app/api/auth/[...nextauth]/route.ts
+++ b/ai_front/nextjs-dashboard/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth'
+import { authOptions } from '@/lib/authOptions'
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }

--- a/ai_front/nextjs-dashboard/src/app/auth/login/page.tsx
+++ b/ai_front/nextjs-dashboard/src/app/auth/login/page.tsx
@@ -39,13 +39,6 @@ export default function LoginPage() {
     }
   };
 
-  const handleGoogleSuccess = (user: any) => {
-    router.push('/');
-  };
-
-  const handleGoogleError = (error: string) => {
-    setError(error);
-  };
 
   return (
     <div className="min-h-screen bg-gray-50 flex">
@@ -118,11 +111,7 @@ export default function LoginPage() {
 
           {/* Google Sign In */}
           <div className="mb-6">
-            <GoogleAuth 
-              onSuccess={handleGoogleSuccess}
-              onError={handleGoogleError}
-              buttonText="Sign in with Google"
-            />
+            <GoogleAuth buttonText="Sign in with Google" />
           </div>
 
           {/* Divider */}

--- a/ai_front/nextjs-dashboard/src/app/auth/signup/page.tsx
+++ b/ai_front/nextjs-dashboard/src/app/auth/signup/page.tsx
@@ -71,13 +71,6 @@ export default function SignUpPage() {
     }
   };
 
-  const handleGoogleSuccess = (user: any) => {
-    router.push('/');
-  };
-
-  const handleGoogleError = (error: string) => {
-    setError(error);
-  };
 
   const passwordStrength = () => {
     const password = formData.password;
@@ -165,11 +158,7 @@ export default function SignUpPage() {
 
           {/* Google Sign Up */}
           <div className="mb-6">
-            <GoogleAuth 
-              onSuccess={handleGoogleSuccess}
-              onError={handleGoogleError}
-              buttonText="Sign up with Google"
-            />
+            <GoogleAuth buttonText="Sign up with Google" />
           </div>
 
           {/* Divider */}

--- a/ai_front/nextjs-dashboard/src/app/login/page.tsx
+++ b/ai_front/nextjs-dashboard/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { signIn } from 'next-auth/react';
 
 export default function LoginPage() {
   const [formData, setFormData] = useState({
@@ -120,7 +121,10 @@ export default function LoginPage() {
           </div>
 
           <div className="mt-4 flex flex-col space-y-2">
-            <button className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors">
+            <button
+              onClick={() => signIn('google')}
+              className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
               Continue with Google
             </button>
             <button className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors">

--- a/ai_front/nextjs-dashboard/src/app/signup/page.tsx
+++ b/ai_front/nextjs-dashboard/src/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import Link from "next/link";
+import { signIn } from 'next-auth/react';
 
 export default function SignupPage() {
   const [formData, setFormData] = useState({
@@ -178,7 +179,10 @@ export default function SignupPage() {
           </div>
 
           <div className="mt-4 flex flex-col space-y-2">
-            <button className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors">
+            <button
+              onClick={() => signIn('google')}
+              className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
               Continue with Google
             </button>
             <button className="p-3 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors">

--- a/ai_front/nextjs-dashboard/src/components/GoogleAuth.tsx
+++ b/ai_front/nextjs-dashboard/src/components/GoogleAuth.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { FiLoader } from "react-icons/fi";
+import { signIn } from 'next-auth/react';
 
 interface GoogleAuthProps {
   onSuccess?: (user: any) => void;
@@ -19,28 +20,10 @@ export default function GoogleAuth({
 
   const handleGoogleSignIn = async () => {
     setIsLoading(true);
-    
     try {
-      // Simulate Google OAuth flow
-      // In production, you would integrate with Google OAuth API
-      await new Promise(resolve => setTimeout(resolve, 1500));
-      
-      // Mock successful authentication
-      const mockUser = {
-        id: "google_" + Date.now(),
-        name: "Demo User",
-        email: "demo@gmail.com",
-        avatar: "https://lh3.googleusercontent.com/a/default-user=s96-c",
-        provider: "google",
-        credits: 10.00
-      };
-      
-      // Store user in localStorage for demo
-      localStorage.setItem('user', JSON.stringify(mockUser));
-      
-      onSuccess?.(mockUser);
+      await signIn('google');
     } catch (error) {
-      onError?.("Failed to sign in with Google. Please try again.");
+      onError?.('Failed to sign in with Google.');
     } finally {
       setIsLoading(false);
     }

--- a/ai_front/nextjs-dashboard/src/lib/authOptions.ts
+++ b/ai_front/nextjs-dashboard/src/lib/authOptions.ts
@@ -1,0 +1,12 @@
+import { NextAuthOptions } from 'next-auth'
+import GoogleProvider from 'next-auth/providers/google'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+}


### PR DESCRIPTION
## Summary
- add NextAuth dependency
- configure NextAuth Google provider
- provide API route for NextAuth
- hook Google sign in buttons up to NextAuth

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688864e313e88325930d6e77d34094b2